### PR TITLE
Add smart wallet deployment step

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -57,6 +57,12 @@ const main = async () => {
     personalWalletAddress
   );
   console.log(`Is smart wallet deployed?`, isWalletDeployed);
+  
+  // [Optional] Deploy the smart wallet
+  if (!isWalletDeployed) {
+    await smartWallet.deploy();
+    console.log(`Smart wallet deployed!`);
+  }
 
   // Connect the smart wallet
   const smartWallet = new SmartWallet(config);


### PR DESCRIPTION
Hey, want to first say thank you for this repo - I recently used it as a starting point in a hackathon, and it was a very helpful starting point!

I noticed that you chose not to explicitly deploy the smart account as part of this setup, presumably following the same logic that the ThirdWeb documentation follows - the first time a user attempts a *transaction*, it'll deploy automatically.

I can say that in my use case, I lost about 20 minutes trying to figure out why I wasn't able to *sign* using my smart account from this script, since it seems that the same behavior is not followed on a first signature as it would be on a first transaction. To make it easier for anyone who might use this script in the future, I added a few lines to deploy the smart account if it's not already deployed. 

Let me know what you think!
